### PR TITLE
Configurable request timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # ide
 ensime-plugin.sbt
+.ensime
+.ensime_cache
 *.*~
 
 # sbt

--- a/core/src/main/scala/artie/TestConfig.scala
+++ b/core/src/main/scala/artie/TestConfig.scala
@@ -1,5 +1,7 @@
 package artie
 
+import scala.concurrent.duration._
+
 final case class TestConfig(baseHost: String,
                             basePort: Int,
                             refactoredHost: String,
@@ -8,7 +10,8 @@ final case class TestConfig(baseHost: String,
                             parallelism: Int,
                             stopOnFailure: Boolean,
                             diffLimit: Int,
-                            showProgress: Boolean) {
+                            showProgress: Boolean,
+                            requestTimeout: FiniteDuration) {
 
   val base       = s"$baseHost:$basePort"
   val refactored = s"$refactoredHost:$refactoredPort"
@@ -25,33 +28,40 @@ trait TestConfigOps {
     parallelism   = 1,
     stopOnFailure = true,
     diffLimit     = 1,
-    showProgress  = true
+    showProgress  = true,
+    10.seconds
   )
 
   implicit class ImplicitTestConfigOps(config: TestConfig) {
 
-    /** Number of repetitions of a test case.
+    /** Number of repetitions of a test case (default 1).
       * 
       * @param rep number of repetitions
       */
     def repetitions(rep: Int) = config.copy(repetitions = rep)
 
-    /** Number of parallel running requests.
+    /** Number of parallel running requests (default 1).
       * 
       * @param par number of parallel requests.
       */
     def parallelism(par: Int) = config.copy(parallelism = par)
 
-    /** Should a test case stop when it encounters the first failure?
+    /** Should a test case stop when it encounters the first failure? (default true))
       * 
       * @param stop if `true` a test case will be stopped on first failure.
       */
     def stopOnFailure(stop: Boolean) = config.copy(stopOnFailure = stop)
 
-    /** Maximum number of shown response differences.
+    /** Maximum number of shown response differences (default 1).
       * 
       * @param limit shown diff limit
       */
     def shownDiffsLimit(limit: Int) = config.copy(diffLimit = limit)
+
+    /** Request timeout (default 10 seconds).
+      * 
+      * @param timeout
+      */
+    def requestTimeout(timeout: FiniteDuration) = config.copy(requestTimeout = timeout)
   }
 }

--- a/core/src/main/scala/artie/TestEngine.scala
+++ b/core/src/main/scala/artie/TestEngine.scala
@@ -7,9 +7,15 @@ import scala.util.Random
 import scala.concurrent.{Future, ExecutionContext}
 import scala.concurrent.duration.FiniteDuration
 
+import java.net.SocketTimeoutException
+
 object TestEngine {
 
   type ResponseT = HttpResponse[String]
+
+  final case class RequestTimeoutDiff(request: RequestT, msg: String) extends Diff {
+    def stringify(ind: String) = ind + show(request) + "\nrequest timeout: " + msg
+  }
 
   final case class ResponseCodeDiff(request: RequestT, text: String) extends Diff {
     def stringify(ind: String) = ind + show(request) + "\n" + ind + text
@@ -31,14 +37,19 @@ object TestEngine {
                         (implicit ec: ExecutionContext,
                                   diff: GenericDiffRunner[A]): Future[TestState] = {
     // build and execute a single request and collect responses
-    def request(p: P): Future[(RequestT, ResponseT, ResponseT)] =
+    def request(p: P): Future[(RequestT, Either[Diff, (ResponseT, ResponseT)])] = {
+      val request = requestGen(rand)(p)
+
       Future {
-        val request    = requestGen(rand)(p)
         val base       = ioEffect(toHttpRequest(config.base, request, config.requestTimeout))
         val refactored = ioEffect(toHttpRequest(config.refactored, request, config.requestTimeout))
 
-        (request, base, refactored)
+        (request, Right((base, refactored)))
+      }.recover {
+        case cause: SocketTimeoutException => (request, Left(RequestTimeoutDiff(request, cause.getMessage())))
+        case other                         => throw other
       }
+    }
 
     // stack-safe
     def engine(p: P, state: TestState): Future[TestState] = {
@@ -53,8 +64,9 @@ object TestEngine {
             request(p)
           }
         ).flatMap { responses =>
-          val newState = responses.foldLeft(state) { case (accState, (request, base, refactored)) =>
-            compareResponses(request, base, refactored, read, accState, config.diffLimit)
+          val newState = responses.foldLeft(state) { 
+            case (accState, (request, Right((base, refactored)))) => compareResponses(request, base, refactored, read, accState, config.diffLimit)
+            case (accState, (request, Left(errorDiff)))           => accState.copy(failed = accState.failed + 1, reasons = addReasons(accState, config.diffLimit, Seq(errorDiff)))
           }
 
           if (config.showProgress)
@@ -73,6 +85,12 @@ object TestEngine {
     }
   }
 
+  private def addReasons(state: TestState, diffLimit: Int, reasons: Seq[Diff]): Seq[Diff] =
+    if (state.reasons.length >= diffLimit)
+      state.reasons
+    else
+      reasons ++: state.reasons
+
   private[artie] def compareResponses[A](request: RequestT,
                                          base: HttpResponse[String],
                                          refactored: HttpResponse[String],
@@ -80,34 +98,28 @@ object TestEngine {
                                          state: TestState,
                                          diffLimit: Int)
                                         (implicit diff: GenericDiffRunner[A]): TestState = {
-    def addReasons(reasons: Seq[Diff]): Seq[Diff] =
-      if (state.reasons.length >= diffLimit)
-        state.reasons
-      else
-        reasons ++: state.reasons
-
     if (base.isError && refactored.isError) {
       if (base.code == refactored.code) {
         val reason = ResponseCodeDiff(request, s"invalid:\n  $base\n  $refactored")
 
-        state.copy(invalid = state.invalid + 1, reasons = addReasons(Seq(reason)))
+        state.copy(invalid = state.invalid + 1, reasons = addReasons(state, diffLimit, Seq(reason)))
       }
       else {
         val baseReason   = ResponseCodeDiff(request, "base service status error:\n  " + base)
         val refactReason = ResponseCodeDiff(request, "refactored service status error:\n  " + refactored)
 
-        state.copy(failed = state.failed + 1, reasons = addReasons(Seq(baseReason, refactReason)))
+        state.copy(failed = state.failed + 1, reasons = addReasons(state, diffLimit, Seq(baseReason, refactReason)))
       }
     }
     else if (base.isError) {
       val reason = ResponseCodeDiff(request, "base service status error:\n  " + base)
 
-      state.copy(failed = state.failed + 1, reasons = addReasons(Seq(reason)))
+      state.copy(failed = state.failed + 1, reasons = addReasons(state, diffLimit, Seq(reason)))
     }
     else if (refactored.isError) {
       val reason = ResponseCodeDiff(request, "refactored service status error:\n  " + refactored)
 
-      state.copy(failed = state.failed + 1, reasons = addReasons(Seq(reason)))
+      state.copy(failed = state.failed + 1, reasons = addReasons(state, diffLimit, Seq(reason)))
     }
     else {
       val stateE = for {
@@ -121,7 +133,7 @@ object TestEngine {
         else {
           val reason = ResponseContentDiff(request, differences)
 
-          state.copy(failed = state.failed + 1, reasons = addReasons(Seq(reason)))
+          state.copy(failed = state.failed + 1, reasons = addReasons(state, diffLimit, Seq(reason)))
         }
       }
 

--- a/core/src/test/scala/artie/ArtieDslSpec.scala
+++ b/core/src/test/scala/artie/ArtieDslSpec.scala
@@ -84,12 +84,13 @@ final class ArtieDslSpec(implicit ee: ExecutionEnv) extends Specification {
     }
 
     "create TestConfig" >> {
-      Config("base", 0, "ref", 1) === TestConfig("base", 0, "ref", 1, 1, 1, true, 1, true)
+      Config("base", 0, "ref", 1) === TestConfig("base", 0, "ref", 1, 1, 1, true, 1, true, 10.seconds)
       Config("base", 0, "ref", 1)
         .parallelism(10)
         .repetitions(100)
         .stopOnFailure(false)
-        .shownDiffsLimit(10) === TestConfig("base", 0, "ref", 1, 100, 10, false, 10, true)
+        .shownDiffsLimit(10)
+        .requestTimeout(5.seconds) === TestConfig("base", 0, "ref", 1, 100, 10, false, 10, true, 5.seconds)
     }
 
     "create test case" >> {

--- a/core/src/test/scala/artie/TestEngineSpec.scala
+++ b/core/src/test/scala/artie/TestEngineSpec.scala
@@ -25,10 +25,14 @@ final class TestEngineSpec(implicit ee: ExecutionEnv) extends Specification {
 
   "TestEngine" >> {
     "RequestT to HttpRequest" >> {
-      toHttpRequest("base", get("/uri")) === Http("base/uri")
-      toHttpRequest("base", post("/uri", contentO = Some("content"))) === Http("base/uri").postData("content")
-      toHttpRequest("base", put("/uri", contentO = Some("content"))) === Http("base/uri").put("content")
-      toHttpRequest("base", delete("/uri")) === Http("base/uri").method("DELETE")
+      def compare(l: HttpRequest, r: HttpRequest) = {
+        l.copy(options = Nil) === r.copy(options = Nil)
+      }
+
+      compare(toHttpRequest("base", get("/uri"), 1.second), Http("base/uri").option(HttpOptions.readTimeout(1000)))
+      compare(toHttpRequest("base", post("/uri", contentO = Some("content")), 1.second), Http("base/uri").option(HttpOptions.readTimeout(1000)).postData("content"))
+      compare(toHttpRequest("base", put("/uri", contentO = Some("content")), 1.second), Http("base/uri").option(HttpOptions.readTimeout(1000)).put("content"))
+      compare(toHttpRequest("base", delete("/uri"), 1.second),  Http("base/uri").option(HttpOptions.readTimeout(1000)).method("DELETE"))
     }
 
     "compare HttpResponses from base and refactored" >> {

--- a/core/src/test/scala/artie/TestEngineSpec.scala
+++ b/core/src/test/scala/artie/TestEngineSpec.scala
@@ -82,6 +82,11 @@ final class TestEngineSpec(implicit ee: ExecutionEnv) extends Specification {
       run(null, provs, conf.repetitions(10), gen(provs), read, _ => resp0) must beEqualTo(TestState(10, 0, 0)).awaitFor(1.second)
       run(null, provs, conf.repetitions(10).parallelism(2), gen(provs), read, _ => resp0) must beEqualTo(TestState(10, 0, 0)).awaitFor(1.second)
 
+      // exception handling
+      val req = gen(provs)
+      run(null, provs, conf, req, read, _ => throw new java.net.SocketTimeoutException("test")) must beEqualTo(TestState(0, 0, 1, Seq(RequestTimeoutDiff(req(null)(null), "test")))).awaitFor(1.second)
+      run(null, provs, conf, req, read, _ => throw new NullPointerException("test")) must throwA(new NullPointerException("test")).awaitFor(1.second)
+
       val fakeIo: HttpRequest => HttpResponse[String] = {
         var counter = 0
 


### PR DESCRIPTION
Before a user wasn't able to configure the request timeout used by scalaj-http. That let to failing tests because of long running requests.

To fix that problem I added `TestConfig.requestTimeout`.